### PR TITLE
feat: add object policies for flexible additionalProperties handling

### DIFF
--- a/src/__tests__/schema-object-test.ts
+++ b/src/__tests__/schema-object-test.ts
@@ -248,4 +248,98 @@ describe("JSON Schema (Object)", () => {
       }).ok
     ).toBeFalsy();
   });
+
+  describe("Object Policies", () => {
+    describe("with additionalProperties: false", () => {
+      const baseSchema = {
+        type: "object" as const,
+        properties: {
+          name: { type: "string" as const },
+          age: { type: "number" as const },
+        },
+        additionalProperties: false,
+      };
+      const strictData = { name: "John", age: 30 };
+      const inexactData = { name: "John", age: 30, city: "NYC" };
+
+      test("strict policy (default) - rejects extra properties", () => {
+        const strictDecoder = createValidator(baseSchema, {
+          policies: { objects: "strict" },
+        });
+
+        expect(strictDecoder.decode(strictData).ok).toBeTruthy();
+        expect(strictDecoder.decode(strictData).value).toEqual(strictData);
+
+        // rejects - too wide
+        expect(strictDecoder.decode(inexactData).ok).toBeFalsy();
+      });
+
+      test("default behavior (should be strict) - rejects extra properties", () => {
+        const defaultDecoder = createValidator(baseSchema);
+        // rejects - too wide
+        expect(defaultDecoder.decode(inexactData).ok).toBeFalsy();
+      });
+
+      test("loose policy - allows extra properties but discards them", () => {
+        const looseDecoder = createValidator(baseSchema, {
+          policies: { objects: "loose" },
+        });
+
+        expect(looseDecoder.decode(strictData).ok).toBeTruthy();
+        expect(looseDecoder.decode(strictData).value).toEqual(strictData);
+
+        expect(looseDecoder.decode(inexactData).ok).toBeTruthy();
+        expect(looseDecoder.decode(inexactData).value).toEqual(strictData); // Extra property discarded
+      });
+
+      test("inexact policy - allows extra properties and keeps them", () => {
+        const inexactDecoder = createValidator(baseSchema, {
+          policies: { objects: "inexact" },
+        });
+
+        expect(inexactDecoder.decode(strictData).ok).toBeTruthy();
+        expect(inexactDecoder.decode(strictData).value).toEqual(strictData);
+
+        expect(inexactDecoder.decode(inexactData).ok).toBeTruthy();
+        expect(inexactDecoder.decode(inexactData).value).toEqual(inexactData); // Extra property kept
+      });
+    });
+
+    describe("with additionalProperties: true", () => {
+      const schemaWithAdditionalProps = {
+        type: "object" as const,
+        properties: {
+          name: { type: "string" as const },
+        },
+        additionalProperties: true,
+      };
+
+      test("policies should not affect behavior when additionalProperties is true", () => {
+        // When additionalProperties is true, policy should not matter - always use inexact
+        const strictDecoder = createValidator(schemaWithAdditionalProps, {
+          policies: { objects: "strict" },
+        });
+
+        const looseDecoder = createValidator(schemaWithAdditionalProps, {
+          policies: { objects: "loose" },
+        });
+
+        const inexactDecoder = createValidator(schemaWithAdditionalProps, {
+          policies: { objects: "inexact" },
+        });
+
+        const dataWithExtra = { name: "John", city: "NYC" };
+
+        // All should behave the same (inexact) when additionalProperties is true
+        expect(strictDecoder.decode(dataWithExtra).ok).toBeTruthy();
+        expect(strictDecoder.decode(dataWithExtra).value).toEqual(dataWithExtra);
+
+        expect(looseDecoder.decode(dataWithExtra).ok).toBeTruthy();
+        expect(looseDecoder.decode(dataWithExtra).value).toEqual(dataWithExtra);
+
+        expect(inexactDecoder.decode(dataWithExtra).ok).toBeTruthy();
+        expect(inexactDecoder.decode(dataWithExtra).value).toEqual(dataWithExtra);
+      });
+    });
+  });
 });

--- a/src/__tests__/util/generator.ts
+++ b/src/__tests__/util/generator.ts
@@ -13,6 +13,7 @@ export function createValidator(schema: Schema, args?: ValidatorArgs): D.Decoder
     nsLib: "this.L.",
     resolveRefPointer: args?.resolveRefPointer,
     resolveRefSchema: args?.resolveRefSchema,
+    policies: args?.policies,
   });
   const decoder: D.Decoder<unknown> = new Function(`"use strict"; return ${script}`).bind({
     D,

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -45,6 +45,20 @@ export interface ConverterOptions {
    * and the schema of it is required.
    */
   resolveRefSchema?: (name: string) => Schema;
+
+  /**
+   * Policies for controlling how different schema constructs are handled
+   */
+  policies?: {
+    /**
+     * Controls how objects with additionalProperties: false are handled
+     *
+     * - "strict" (default): Follow JSON schema exactly - use D.exact when additionalProperties: false
+     * - "loose": Use D.object instead of D.exact when additionalProperties: false (allows extra properties but discards them)
+     * - "inexact": Use D.inexact when additionalProperties: false (allows extra properties and keeps them)
+     */
+    objects?: "strict" | "loose" | "inexact";
+  };
 }
 
 /**
@@ -124,7 +138,7 @@ function getSchemaComment(schema: Schema): string[] {
 }
 
 function convertObject(obj: ObjectSchema, opt: ConvertContext): string[] {
-  const { nsPrefix } = opt.options;
+  const { nsPrefix, policies } = opt.options;
   const chain: string[][] = [];
 
   // Non-structured objects require string properties but don't validate the values
@@ -132,8 +146,26 @@ function convertObject(obj: ObjectSchema, opt: ConvertContext): string[] {
     return [`${nsPrefix}dict(${nsPrefix}unknown)`];
   }
 
-  // Check if we should perform exact matching
-  const exactProps = obj.additionalProperties === false && !obj.patternProperties;
+  // Determine the decoder type based on policy
+  function getObjectDecoderType(): string {
+    // Check if we should perform exact matching according to JSON schema
+    const schemaRequiresExact = obj.additionalProperties === false && !obj.patternProperties;
+    if (!schemaRequiresExact) {
+      // If schema allows additional properties, always use inexact
+      return "inexact";
+    }
+
+    // Schema says additionalProperties: false - apply policy
+    const objectPolicy = policies?.objects ?? "strict";
+    switch (objectPolicy) {
+      case "strict":
+        return "exact";
+      case "loose":
+        return "object";
+      case "inexact":
+        return "inexact";
+    }
+  }
 
   // Create the base decoder for validating either well-known properties or a gneric
   // dict type, either strictly or loosely. We will then follow-up chaining additional
@@ -163,11 +195,7 @@ function convertObject(obj: ObjectSchema, opt: ConvertContext): string[] {
         );
       }
     }
-    chain.push([
-      `${nsPrefix}${exactProps ? "exact" : "inexact"}({`,
-      ...indentLines(propLines, 2),
-      `})`,
-    ]);
+    chain.push([`${nsPrefix}${getObjectDecoderType()}({`, ...indentLines(propLines, 2), `})`]);
   } else if (obj.additionalProperties != null && typeof obj.additionalProperties === "object") {
     // If we have 'additional properties' without any strictly defined property,
     // we shoudl emit a dict.
@@ -689,6 +717,7 @@ export function convertSchema(schema: Schema, options?: ConverterOptions): strin
     nsPrefix: options?.nsPrefix ?? "",
     resolveRefPointer: options?.resolveRefPointer,
     resolveRefSchema: options?.resolveRefSchema,
+    policies: options?.policies,
   };
   const ctx: ConvertContext = {
     options: opt,


### PR DESCRIPTION
Add policies.objects configuration option to control how objects with additionalProperties: false are decoded, addressing the limitation of always using strict validation.

Previously, schemas with additionalProperties: false always generated D.exact() decoders, which reject any extra properties. This was too restrictive for many use cases where users wanted more flexibility.

New policies.objects options:
- 'strict' (default): Use D.exact() - rejects extra properties
- 'loose': Use D.object() - allows extra properties but discards them
- 'inexact': Use D.inexact() - allows extra properties and keeps them

This provides a clamp-style configuration that lets users choose their preferred validation strictness while maintaining full backward compatibility. When additionalProperties is true, behavior remains unchanged (always uses D.inexact).

- Add policies configuration to ConverterOptions interface
- Modify convertObject() to respect object policy settings
- Add comprehensive test coverage for all three policy modes
- Refactor test structure for better organization